### PR TITLE
Clear fallback font cache

### DIFF
--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_de.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_de.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: Hallo
+    m_Localized: Hallo Musik
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_en.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_en.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: Hello
+    m_Localized: Hello Music
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_es-ES.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_es-ES.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: Hola
+    m_Localized: "Hola M\xFAsica"
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_fr.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_fr.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: Bonjour
+    m_Localized: Bonjour Musique
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_ja.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_ja.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: "\u3053\u3093\u306B\u3061\u306F"
+    m_Localized: "\u3053\u3093\u306B\u3061\u306F \u97F3\u697D"
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_pt-BR.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_pt-BR.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: "Ol\xE1"
+    m_Localized: "Ol\xE1 M\xFAsica"
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_ru.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_ru.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: "\u041F\u0440\u0438\u0432\u0435\u0442"
+    m_Localized: "\u041F\u0440\u0438\u0432\u0435\u0442 \u041C\u0443\u0437\u044B\u043A\u0430"
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_zh.asset
+++ b/src/SystemFontLocalization/Assets/Sample/Data/LocalizationTexts/SampleText_zh.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     m_Items: []
   m_TableData:
   - m_Id: 208537948160
-    m_Localized: "\u4F60\u597D"
+    m_Localized: "\u4F60\u597D \u97F3\u4E50"
     m_Metadata:
       m_Items: []
   references:

--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/CHANGELOG.md
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## [0.7.0] - 2024-05-13
+## [0.7.1] - 2024-05-13
 ### Fixed
+- Fixed an issue where old fonts remained.
+
+## [0.7.0] - 2024-05-13
+### Change
 - Support regex for language code and font name. Format of SystemFontNameList has been updated.
 
 ## [0.6.0] - 2024-03-25

--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/Scripts/SystemFontReplacer.cs
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/Scripts/SystemFontReplacer.cs
@@ -93,6 +93,14 @@ namespace FontLocalization
                 }
 
                 fontData.LanguageCode = languageCode;
+                for (int j = 0; j < fontData.BaseFontAsset.fallbackFontAssetTable.Count; j++)
+                {
+                    var oldFallback = fontData.BaseFontAsset.fallbackFontAssetTable[j];
+                    if (oldFallback != null)
+                    {
+                        Object.Destroy(oldFallback);
+                    }
+                }
                 fontData.BaseFontAsset.fallbackFontAssetTable.Clear();
                 fontData.BaseFontAsset.fallbackFontAssetTable.Add(fallbackFontAsset);
                 Debug.Log($"Fallback font is replaced. {languageCode}");

--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/package.json
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.system-font-localization",
     "displayName": "System Font Localization",
-    "version": "0.7.0",             
+    "version": "0.7.1",             
     "unity": "2022.3",
     "description": "Auto generate fallback font asset by system font in runtime.",
     "author": {


### PR DESCRIPTION
Fixed an issue where old fonts remained.
This occurred when switching between Japanese and Chinese.