### PR TITLE
Fix regex in DefaultSystemFontNameList.asset

### DIFF
--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/CHANGELOG.md
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [0.7.3] - Develop
+## [0.7.4] - Develop
+### Fixed
+- Added start and end characters to the regex in DefaultSystemFontNameList.asset.  
+  - This fixes the issue where unintended Chinese fonts were being selected.
+
+## [0.7.3] - 2024-10-31
 ### Added
 - Added Japanese font (Yu Gothic)
 ### Fixed

--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/Data/DefaultSystemFontNameList.asset
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/Data/DefaultSystemFontNameList.asset
@@ -15,22 +15,22 @@ MonoBehaviour:
   _settings:
   - _languageCode: ja
     _fontNames:
-    - '[Yy]u\s*[Gg]oth[Mm]'
-    - '[Yy]u\s*[Gg]oth*'
-    - '[Mm][Ss]\s*[Gg]othic'
-    - '[Mm][Ss]\s*[Mm]incho'
-    - '[Hh]iragino\s*[Kk]aku\s*[Gg]othic'
-    - '[Hh]iragino.*'
+    - ^[Yy]u\s*[Gg]oth[Mm]$
+    - ^[Yy]u\s*[Gg]oth
+    - ^[Mm][Ss]\s*[Gg]othic$
+    - ^[Mm][Ss]\s*[Mm]incho$
+    - ^[Hh]iragino\s*[Kk]aku\s*[Gg]othic$
+    - ^[Hh]iragino
   - _languageCode: zh
     _fontNames:
-    - '[Ss]im\s*[Ss]un'
-    - '[Hh]ei'
+    - ^[Ss]im\s*[Ss]un$
+    - ^[Hh]ei$
   - _languageCode: ko
     _fontNames:
-    - '[Mm]algun'
-    - '[Bb]atang'
-    - '[Aa]pple\s*[Gg]othic'
+    - ^[Mm]algun$
+    - ^[Bb]atang$
+    - ^[Aa]pple\s*[Gg]othic$
   - _languageCode: .*
     _fontNames:
-    - '[Aa]rial'
-    - '[Aa]rial.*'
+    - ^[Aa]rial$
+    - ^[Aa]rial.*

--- a/src/SystemFontLocalization/Assets/SystemFontLocalization/package.json
+++ b/src/SystemFontLocalization/Assets/SystemFontLocalization/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.system-font-localization",
     "displayName": "System Font Localization",
-    "version": "0.7.3",             
+    "version": "0.7.4",             
     "unity": "2022.3",
     "description": "Auto generate fallback font asset by system font in runtime.",
     "author": {

--- a/src/SystemFontLocalization/Packages/manifest.json
+++ b/src/SystemFontLocalization/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.4.3",
+    "com.unity.collab-proxy": "2.5.2",
     "com.unity.feature.development": "1.0.1",
     "com.unity.localization": "1.5.2",
     "com.unity.textmeshpro": "3.2.0-pre.6",

--- a/src/SystemFontLocalization/Packages/packages-lock.json
+++ b/src/SystemFontLocalization/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.addressables": {
-      "version": "1.21.21",
+      "version": "1.22.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -9,13 +9,13 @@
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.imageconversion": "1.0.0",
         "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.scriptablebuildpipeline": "1.21.23",
+        "com.unity.scriptablebuildpipeline": "1.21.25",
         "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.4.3",
+      "version": "2.5.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -41,16 +41,16 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.ide.visualstudio": "2.0.22",
-        "com.unity.ide.rider": "3.0.31",
+        "com.unity.ide.rider": "3.0.34",
         "com.unity.ide.vscode": "1.2.5",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.performance.profile-analyzer": "1.2.2",
         "com.unity.test-framework": "1.1.33",
-        "com.unity.testtools.codecoverage": "1.2.5"
+        "com.unity.testtools.codecoverage": "1.2.6"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.31",
+      "version": "3.0.34",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -99,7 +99,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.21.23",
+      "version": "1.21.25",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -124,7 +124,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/src/SystemFontLocalization/ProjectSettings/ProjectVersion.txt
+++ b/src/SystemFontLocalization/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.39f1
-m_EditorVersionWithRevision: 2022.3.39f1 (4e1b0f82c39a)
+m_EditorVersion: 2022.3.54f1
+m_EditorVersionWithRevision: 2022.3.54f1 (129125d4e700)


### PR DESCRIPTION
- Added start and end characters to the regex in DefaultSystemFontNameList.asset.  
  - This fixes the issue where unintended Chinese fonts were being selected.